### PR TITLE
Из примеров убран устаревший параметр `warm_cache`

### DIFF
--- a/public-api-example/public-api-examples-notebook.ipynb
+++ b/public-api-example/public-api-examples-notebook.ipynb
@@ -649,7 +649,6 @@
     "    \"script\": \"/home/jovyan/test_script.py\",\n",
     "    \"n_workers\": 2,\n",
     "    \"n_gpus\": 2,\n",
-    "    \"warm_cache\": \"True\",\n",
     "    \"flags\" : {\n",
     "        \"batch_size\": \"512\",\n",
     "        \"model\":\"resnet50\",\n",

--- a/quick-start/job_launch/quick-start.ipynb
+++ b/quick-start/job_launch/quick-start.ipynb
@@ -220,13 +220,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[36mINFO\u001b[0m[0005] Resolved base name cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 to cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n",
-      "\u001b[36mINFO\u001b[0m[0005] Resolved base name cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 to cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n",
-      "\u001b[36mINFO\u001b[0m[0005] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n",
-      "\u001b[36mINFO\u001b[0m[0005] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n",
-      "\u001b[36mINFO\u001b[0m[0005] Built cross stage deps: map[]                \n",
-      "\u001b[36mINFO\u001b[0m[0005] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n",
-      "\u001b[36mINFO\u001b[0m[0006] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n"
+      "\u001B[36mINFO\u001B[0m[0005] Resolved base name cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 to cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n",
+      "\u001B[36mINFO\u001B[0m[0005] Resolved base name cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 to cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n",
+      "\u001B[36mINFO\u001B[0m[0005] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n",
+      "\u001B[36mINFO\u001B[0m[0005] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n",
+      "\u001B[36mINFO\u001B[0m[0005] Built cross stage deps: map[]                \n",
+      "\u001B[36mINFO\u001B[0m[0005] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n",
+      "\u001B[36mINFO\u001B[0m[0006] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0 \n"
      ]
     }
    ],
@@ -253,7 +253,7 @@
     "```python\n",
     "mnist_tf_run = client_lib.Job(base_image=job.new_image, # кастомный образ\n",
     "                              script='/home/jovyan/quick-start/job_launch/tensorflow_mnist_estimator.py',\n",
-    "                              n_workers=2, n_gpus=4, warm_cache=False)\n",
+    "                              n_workers=2, n_gpus=4)\n",
     "```"
    ]
   },
@@ -267,7 +267,7 @@
     "#     базовый образ, можно заменить на свой (смотри выше)\n",
     "mnist_tf_run = client_lib.Job(base_image='cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda10.0-tf1.15.0-pt1.3.0',\n",
     "                              script='/home/jovyan/quick-start/job_launch/tensorflow_mnist_estimator.py',\n",
-    "                              n_workers=2, n_gpus=4, warm_cache=False)"
+    "                              n_workers=2, n_gpus=4)"
    ]
   },
   {

--- a/quick-start/job_launch_tf2/quick-start-v100.ipynb
+++ b/quick-start/job_launch_tf2/quick-start-v100.ipynb
@@ -172,13 +172,13 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "\u001b[36mINFO\u001b[0m[0006] Resolved base name cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 to cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n",
-      "\u001b[36mINFO\u001b[0m[0006] Resolved base name cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 to cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n",
-      "\u001b[36mINFO\u001b[0m[0006] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n",
-      "\u001b[36mINFO\u001b[0m[0006] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n",
-      "\u001b[36mINFO\u001b[0m[0007] Built cross stage deps: map[]                \n",
-      "\u001b[36mINFO\u001b[0m[0007] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n",
-      "\u001b[36mINFO\u001b[0m[0007] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n"
+      "\u001B[36mINFO\u001B[0m[0006] Resolved base name cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 to cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n",
+      "\u001B[36mINFO\u001B[0m[0006] Resolved base name cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 to cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n",
+      "\u001B[36mINFO\u001B[0m[0006] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n",
+      "\u001B[36mINFO\u001B[0m[0006] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n",
+      "\u001B[36mINFO\u001B[0m[0007] Built cross stage deps: map[]                \n",
+      "\u001B[36mINFO\u001B[0m[0007] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n",
+      "\u001B[36mINFO\u001B[0m[0007] Retrieving image manifest cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1 \n"
      ]
     }
    ],
@@ -205,7 +205,7 @@
     "```python\n",
     "mnist_tf_run = client_lib.Job(base_image=job.new_image, # кастомный образ\n",
     "                              script='/home/jovyan/quick-start/job_launch_tf2/tensorflow_mnist_estimator.py',\n",
-    "                              n_workers=2, n_gpus=4, warm_cache=False)\n",
+    "                              n_workers=2, n_gpus=4)\n",
     "```"
    ]
   },
@@ -220,7 +220,7 @@
     "mnist_tf_run = client_lib.Job(\n",
     "    base_image='cr.msk.sbercloud.ru/aicloud-base-images/horovod-cuda11.0-tf2.4.0-pt1.7.1',\n",
     "    script='/home/jovyan/quick-start/job_launch_tf2/tensorflow_mnist_estimator.py',\n",
-    "    n_workers=2, n_gpus=4, warm_cache=False)"
+    "    n_workers=2, n_gpus=4)"
    ]
   },
   {


### PR DESCRIPTION
Из примеров запуска Job'ов с помощью client_lib и public-api убран устаревший параметр `warm_cache`, в рамках подготовки к его удалению.